### PR TITLE
Fix nil CurrentTime errors in timed traits

### DIFF
--- a/src/ready.lua
+++ b/src/ready.lua
@@ -548,12 +548,13 @@ if config.SlowEffectsOnTimer.Enabled then
 		if HeroHasTrait("TimedBuffKeepsake") then
 			if not IsBiomeTimerPaused() then
 				local traitData = GetHeroTrait("TimedBuffKeepsake")
+				traitData.CurrentTime = traitData.CurrentTime or 0
 				traitData.CurrentTime = traitData.CurrentTime - elapsed
-				if traitData.CurrentTime  <= 0 and (traitData.CurrentTime  + elapsed) > 0 then
+				if traitData.CurrentTime <= 0 and (traitData.CurrentTime + elapsed) > 0 then
 					traitData.CustomName = traitData.ZeroBonusTrayText
-					EndTimedBuff( traitData )
-					thread( TimedBuffExpiredPresentation, traitData )
-					ReduceTraitUses( traitData, {Force = true } )
+					EndTimedBuff(traitData)
+					thread(TimedBuffExpiredPresentation, traitData)
+					ReduceTraitUses(traitData, { Force = true })
 				end
 			end
 		end
@@ -561,18 +562,20 @@ if config.SlowEffectsOnTimer.Enabled then
 		if HeroHasTrait("ChaosTimeCurse") then
 			if not IsBiomeTimerPaused() then
 				local traitData = GetHeroTrait("ChaosTimeCurse")
+				traitData.CurrentTime = traitData.CurrentTime or 0
+
 				traitData.CurrentTime = traitData.CurrentTime - elapsed
 				local threshold = 30
-				if traitData.CurrentTime  <= threshold and (traitData.CurrentTime  + elapsed) > threshold then
-					ChaosTimerAboutToExpirePresentation(threshold )
-				elseif traitData.CurrentTime  <= 0 and (traitData.CurrentTime  + elapsed) > 0 then
+				if traitData.CurrentTime <= threshold and (traitData.CurrentTime + elapsed) > threshold then
+					ChaosTimerAboutToExpirePresentation(threshold)
+				elseif traitData.CurrentTime <= 0 and (traitData.CurrentTime + elapsed) > 0 then
 					if not CurrentRun.Hero.InvulnerableFlags.BlockDeath then
 						CurrentRun.CurrentRoom.Encounter.TookChaosCurseDamage = true
 						CurrentRun.CurrentRoom.KilledByChaosCurse = true
-						thread( SacrificeHealth, { SacrificeHealthMin = traitData.Damage, SacrificeHealthMax = traitData.Damage, MinHealth = 0, AttackerName = "TrialUpgrade" } )
+						thread(SacrificeHealth, { SacrificeHealthMin = traitData.Damage, SacrificeHealthMax = traitData.Damage, MinHealth = 0, AttackerName = "TrialUpgrade" })
 					end
 					if not CurrentRun.Hero.IsDead then
-						thread( RemoveTraitData, CurrentRun.Hero, traitData )
+						thread(RemoveTraitData, CurrentRun.Hero, traitData)
 					end
 				end
 			end


### PR DESCRIPTION
In order to fix this error:

> [Engine.Native\Code\Helpers\LuaExt.cpp:393] Script error: ...t\ReturnOfModding\plugins\PonyWarrior-PonyQOL2/ready.lua:551: attempt to perform arithmetic on field 'CurrentTime' (a nil value)

Ensure traitData.CurrentTime is initialized before arithmetic in
TimedBuffKeepsake and ChaosTimeCurse traits to prevent Lua runtime
errors when the value is nil.